### PR TITLE
Exception thrown when running scenarios with ganache config

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "0x.js": "^2.0.0",
         "@0x/abi-gen-wrappers": "^1.0.1",
         "@0x/connect": "^3.0.0",
-        "@0x/contract-addresses": "^1.0.1",
+        "@0x/contract-addresses": "^2.0.0",
         "@0x/contract-artifacts": "^1.0.1",
         "@0x/subproviders": "^2.0.7",
         "@0x/web3-wrapper": "^3.1.0",


### PR DESCRIPTION
```
throw new Error(`Unknown network id (${networkId}). No known 0x contracts have been deployed on this network.`);
```

It is because  `contract-addresses` v1.0.1 doesn't recognise the ganache network_id(50). 