### PR TITLE
adds --force to npm install yarn to fix circle ci build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
                       - v1-dependencies-
             - run:
                   name: install-yarn
-                  command: sudo npm install --global yarn@1.9.4
+                  command: sudo npm install --global yarn@1.9.4 --force
             - run:
                   name: yarn
                   command: yarn --frozen-lockfile install || yarn --frozen-lockfile install


### PR DESCRIPTION
## Objective:
- Fix circle ci builds failing

## Changes
- Add --force to ensure that if yarn is already installed in the build container's base image that we ensure that we reinstall with an appropriate version

## Suggestions / Question for maintainers
- Is there a specific reason to pin yarn to 1.9.4? If not, we should consider removing the explicit yarn version declaration and entirely remove this step from the CI pipeline to simplify & speed up the build process.  I will be opening another pull request with this change and linking it here in an edit shortly. 