### PR TITLE
chore: add deprecation notice and remove yanked npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # 0x Starter Project
 
+## ⚠️ Deprecation Warning ️️⚠️
+
+This project does **not support 0x Protocol V4** and is no longer being actively maintained.
+
 [![CircleCI](https://circleci.com/gh/0xProject/0x-starter-project.svg?style=svg)](https://circleci.com/gh/0xProject/0x-starter-project)
 
 ![cli](https://user-images.githubusercontent.com/27389/42074402-6dcc5ccc-7baf-11e8-84f1-9a27f1a96b08.png)

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
         "copyfiles": "^2.1.1",
         "ethereumjs-util": "^6.1.0",
         "express": "^4.17.1",
-        "http": "^0.0.0",
         "lodash": "^4.17.15",
         "ora": "^3.4.0",
         "run-s": "^0.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,10 +4139,6 @@ http-status-codes@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
 
-http@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/http/-/http-0.0.0.tgz#86e6326d29c5d039de9fac584a45689f929f4f72"
-
 iconv-lite@0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Since we will not bring this to V4 we should deprecate it. 

Additionally it had a `http` package dependency, which is now part of the node standard library and does not need to be installed so I removed that.